### PR TITLE
New Script - wand-watcher.lic

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1432,3 +1432,20 @@ duskruin:
 
 #turn on heal/remedy text subs by ingredient name: yelith (limb-IW) tonic
 herb_textsubs: false
+
+# Settings used for wand-watcher, which uses 'wands' (ex: bloodwood branch) based on timers
+# See: https://elanthipedia.play.net/Lich_script_repository#wand-watcher for details
+wands:
+  # magic wand:                     # Adj + Noun of the wand.  Must be unique  [Mandatory]
+  #   activation message: Foo Bar   # Spell activation message                 [Mandatory]
+  #   activation verb: tap          # Verb used to activate the wand           [Optional - defaults to 'tap']
+  #   container: backpack           # Container where the wand(s) are stored   [Mandatory]
+  #   cooldown: 32                  # minutes between activation attempts      [Optional - defaults to 30]
+  #   count: 2                      # number of wands you have                 [Optional - defaults to 2]
+
+wand_watcher_no_use_scripts:  # Don't try to grab any wands while these scripts are running.
+  - burgle
+  - go2
+
+wand_watcher_startup_delay: 10  # Wait n seconds on startup before doing anything   [Optional - defaults to 10 s]
+wand_watcher_passive_delay: 60  # How long to wait between checks for reusing wands [Optional - defaults to 60 s]

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -1,0 +1,153 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#wand-watcher
+=end
+
+no_kill_all
+no_pause_all
+
+custom_require.call(%w[common common-items])
+
+class WandWatcher
+  include DRC
+  include DRCI
+
+  def initialize
+    settings = get_settings();
+    @wand_list = settings.wands
+    @queued_wands = []
+    @no_use_scripts = settings.wand_watcher_no_use_scripts || []
+    @startup_delay = settings.wand_watcher_startup_delay || 10
+    @passive_delay = settings.wand_watcher_passive_delay || 60
+    @activation_failure_messages = [/^The .* remains inert/]
+    UserVars.wand_watcher_timers = {} unless UserVars.wand_watcher_timers
+
+    #don't allow users to make foolish mistakes, always prevent use during go2/burgle
+    @no_use_scripts << 'go2'
+    @no_use_scripts << 'burgle'
+
+    # rebuild UserVars based on what wands are listed in the yaml
+    # this preserves timers existing wands, removes timers for wands no longer in the yaml
+    # and sets new wand next use timers to now
+    temp_timers = {}
+    @wand_list.each do |key,item|
+      if UserVars.wand_watcher_timers[key]
+        temp_timers[key] = UserVars.wand_watcher_timers[key]
+      else
+        temp_timers[key] = Time.now
+      end
+    end
+    UserVars.wand_watcher_timers = temp_timers
+    
+    #startup delay so you can control spammyness of autostart scripts
+    pause @startup_delay
+
+    #run passively
+    passive_run
+    #TODO: run once option
+  end
+
+  def passive_run
+    loop do
+      if @wand_list == nil || @wand_list.empty?
+        #@wand_list = nil when no wands configured in yaml
+        #@wand_list = empty when all wands are deleted due to problems finding wands
+        message "No wands to check.  Ending script.  Double check your settings."
+        exit
+      end
+      check_timers
+      pause @passive_delay
+    end
+  end
+
+  def check_timers  
+    #if any no_use_scripts are running, loop every 10 seconds checking until not
+    loop do
+      break if !(@no_use_scripts.any? { |name| Script.running?(name) })
+      pause 10
+    end
+    
+    #Loop through the wand timers in the UserVars, and queue up any wands that are ready to go
+    UserVars.wand_watcher_timers.each do |wand,next_use_time|
+      if Time.now > next_use_time
+        @queued_wands << wand
+      end
+    end
+
+    #If you have any queued wands, use them, then reset the list of queued wands
+    if !@queued_wands.empty?
+      use_wands
+      @queued_wands = []
+    end
+  end
+
+  def use_wands
+    #pause scripts to prevent interference
+    scripts_to_unpause = []
+    scripts_to_unpause = smart_pause_all
+    
+    #if both hands are full, store the left hand item in a variable for future use and lower the 
+    #left hand to the feet slot.  
+    #left causes less problems with combat (less likely to be a loaded weapon)
+    #feet slot causes less space/correct container issues
+    temp_left_item = nil
+    if DRC.right_hand && DRC.left_hand
+      temp_left_item = DRC.left_hand
+      bput("lower ground left",/^You lower/)
+    end
+
+    #redo_count prevents infinite loops when getting a failure message on activation
+    redo_count = 0
+
+    @queued_wands.each do |wand|
+      #get wand settings
+      activation_successful_message = @wand_list[wand]['activation message']
+      activation_verb = @wand_list[wand]['activate verb'] || 'tap'
+      container = @wand_list[wand]['container'] 
+      cooldown = @wand_list[wand]['cooldown'] || 30
+      count = @wand_list[wand]['count'] || 2
+
+      #cooldown is stored in minutes, but used in seconds
+      cooldown *= 60
+      #count is stored as number you own, but ordinals is based on 0 index
+      count -= 1
+      
+      #If you fail getting the wand, because you don't have the right number, or it's not in the 
+      #right container, or you simply don't have them, message the user, and remove the wand from
+      #the list of wands checked
+      if !get_item("#{$ORDINALS[count]} #{wand}",container)
+        message "Could not find correct number of wands for #{wand} in #{container}."
+        message "Double check your wand name, count, an container settings." 
+        message "Removing this wand from the list."
+        @wand_list.delete(wand)
+        UserVars.wand_watcher_timers.delete(wand)
+        next
+      end
+
+      case bput("#{activation_verb} my #{wand}",activation_successful_message,@activation_failure_messages)
+      when *activation_successful_message
+        #set next use timer to now + cooldown
+        UserVars.wand_watcher_timers[wand] = Time.now + cooldown
+      when *@activation_failure_messages
+        #if activation fails, could just be a sort issue due login.
+        #retry, until you succeed, or run out of wands
+        put_away_item?(wand,container)
+        redo_count += 1
+        redo unless redo_count > count
+        #try again in 1/2 the cooldown time
+        UserVars.wand_watcher_timers[wand] = Time.now + (cooldown / 2)
+      end
+
+      #put away the wand and reset the redo counter for next wand
+      put_away_item?(wand,container)
+      redo_count = 0
+    end
+   
+    #pick item back up if you lowered something
+    bput("get #{temp_left_item}",/^You pick up/) if temp_left_item != nil
+
+    #resume scripts
+    unpause_all_list(scripts_to_unpause)
+  end
+end
+
+WandWatcher.new


### PR DESCRIPTION
Generalized version of mefwatch from repository. Should work with all kinds of wands, and bases its activation on timers, instead of needing to check if the spell/effect is still active.

Script runs in background and waits for the next time to use a wand.  It stores these times as UserVars.

Example settings:

```yaml
wands:
  # magic wand:                     #Adj + Noun of the wand.  Must be unique  [Mandatory]
  #   activation message: Foo Bar   #Spell activation message                 [Mandatory]
  #   activation verb: tap          #Verb used to activate the wand           [Optional - defaults to 'tap']
  #   container: backpack           #Container where the wand(s) are stored   [Mandatory]
  #   cooldown: 32                  #minutes between activation attempts      [Optional - defaults to 30]
  #   count: 2                      #number of wands you have                 [Optional - defaults to 2]
  bloodwood branch:
    activation message: The world around you seems to slow as the spell grips your mind.
    activation verb: tap
    container: rucksack
    cooldown: 32
    count: 2

wand_watcher_no_use_scripts:  # Don't try to grab any wands while these scripts are running.
  - burgle
  - go2

wand_watcher_startup_delay: 10  # Wait n seconds on startup before doing anything   [Optional - defaults to 10 s]
wand_watcher_passive_delay: 60  # How long to wait between checks for reusing wands [Optional - defaults to 60 s]
```